### PR TITLE
dune 3.0 compatibility

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.3)
+(lang dune 2.9)
 (name ubpf)

--- a/src/dune
+++ b/src/dune
@@ -3,6 +3,9 @@
   (public_name ubpf)
   (libraries ubpf_c)
   (wrapped false)
-  (cxx_names ubpf_stubs bpf)
-  (cxx_flags :standard -std=c++11 -Iubpf_c/ubpf/vm/inc)
+  (foreign_stubs
+   (include_dirs ubpf_c/ubpf/vm/inc)
+   (language cxx)
+   (names ubpf_stubs bpf)
+   (flags :standard -std=c++11))
   (c_library_flags :standard -lstdc++))

--- a/src/ubpf_c/dune
+++ b/src/ubpf_c/dune
@@ -2,15 +2,14 @@
   (name ubpf_c)
   (public_name ubpf.c)
   (c_library_flags (:standard -lstdc++))
-  (self_build_stubs_archive (ubpf_c)))
+  (foreign_archives ubpf_c))
 
-(ignored_subdirs (ubpf))
+(data_only_dirs ubpf)
 
 (rule
   (deps (source_tree ubpf))
-  (targets libubpf_c_stubs.a dllubpf_c_stubs.so)
+  (targets libubpf_c.a dllubpf_c.so)
   (action (progn
             (chdir ubpf/vm (run make))
-            (bash "cp ubpf/vm/libubpf.a libubpf_c_stubs.a")
-            (bash "cp ubpf/vm/dllubpf.so dllubpf_c_stubs.so")
-)))
+            (bash "cp ubpf/vm/libubpf.a libubpf_c.a")
+            (bash "cp ubpf/vm/dllubpf.so dllubpf_c.so"))))

--- a/ubpf.opam
+++ b/ubpf.opam
@@ -17,8 +17,7 @@ available: [
 ]
 depends: [
   "ocaml" {>= "4.02"}
-  "ocamlfind" {build}
-  "dune" {build}
+  "dune" {>= "2.9.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
The current build does not specify dependencies correctly and is currently broken with the upcoming dune 3.0. This PR fixes the build so that it will work with 2.9.x and 3.0.